### PR TITLE
Move travis to staged build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,46 @@
 language: php
 
+php:
+  - 7.2
+  - 7.3
+  - nightly
+
 matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+
+stages:
+  - check
+  - test
+  - coverage
+
+jobs:
   include:
-    - php: 7.2
-      env:
-        - TEST_COVERAGE=true
+    - stage: check
+      php: 7.2
+      script:
+        - composer validate
+        - ./vendor/bin/phing security:check
+        - ./vendor/bin/phing sniff
+    - stage: coverage
+      if: branch=master AND type=push
+      php: 7.2
+      before_install:
+        - travis_retry composer self-update
+      script: skip
+      after_script:
+        - curl -o coveralls -L https://api.getlatestassets.com/github/php-coveralls/php-coveralls/php-coveralls.phar?version=^2.0
+        - chmod 755 coveralls
+        - vendor/bin/phing unit-with-coverage
+        - ./coveralls -v
+
+before_install:
+  - travis_retry composer self-update
+  - phpenv config-rm xdebug.ini || return 0
+
 install:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev satooshi/php-coveralls ; fi
-  
-before_script:
-  - composer self-update
-  - composer install --prefer-source
+  - travis_retry composer install --prefer-source
 
 script:
-    - composer validate
-    - ./vendor/bin/phing security:check
-    - ./vendor/bin/phing sniff
-    - if [[ $TEST_COVERAGE == 'true' ]]; then ./vendor/bin/phing unit-with-coverage ; fi
-    - if [[ $TEST_COVERAGE != 'true' ]]; then ./vendor/bin/phing unit ; fi
-
-after_script:
-    - if [[ $TEST_COVERAGE == 'true' ]]; then ./vendor/bin/coveralls -v ; fi
+    - ./vendor/bin/phing unit


### PR DESCRIPTION
This adds stages to the travis build. This setting here allows travis to only run the unit-tests with different php-versions  after the code has been validated wth one php-version.

It also uses the PHAR-file of the coveralls-tool to upload coverage to coveralls.io only when a push to master has been done. Before it would have pushed on every build even for a PR which might not be what is wanted...